### PR TITLE
Adds support for workspace/symbol

### DIFF
--- a/src/StaticLS/IDE/Workspace/Symbol.hs
+++ b/src/StaticLS/IDE/Workspace/Symbol.hs
@@ -16,4 +16,3 @@ symbolInfo query = do
     let hiedbDefs = fromMaybe [] mHiedbDefs
         symbols = map AtPoint.defRowToSymbolInfo hiedbDefs
     pure (catMaybes symbols)
-

--- a/src/StaticLS/IDE/Workspace/Symbol.hs
+++ b/src/StaticLS/IDE/Workspace/Symbol.hs
@@ -1,0 +1,19 @@
+module StaticLS.IDE.Workspace.Symbol where
+
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans.Maybe (MaybeT (..))
+import Data.Maybe
+import qualified Data.Text as T
+import qualified Development.IDE.Spans.AtPoint as AtPoint
+import GHC.Plugins hiding ((<>))
+import qualified HieDb
+import Language.LSP.Types
+import StaticLS.StaticEnv
+
+symbolInfo :: (HasCallStack, HasStaticEnv m, MonadIO m) => T.Text -> m [SymbolInformation]
+symbolInfo query = do
+    mHiedbDefs <- runMaybeT . runHieDbMaybeT $ \hieDb -> HieDb.searchDef hieDb (T.unpack query)
+    let hiedbDefs = fromMaybe [] mHiedbDefs
+        symbols = map AtPoint.defRowToSymbolInfo hiedbDefs
+    pure (catMaybes symbols)
+

--- a/src/StaticLS/Server.hs
+++ b/src/StaticLS/Server.hs
@@ -3,7 +3,6 @@
 
 module StaticLS.Server where
 
-import StaticLS.IDE.Workspace.Symbol
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except
@@ -19,6 +18,7 @@ import Language.LSP.Types
 import StaticLS.IDE.Definition
 import StaticLS.IDE.Hover
 import StaticLS.IDE.References
+import StaticLS.IDE.Workspace.Symbol
 import StaticLS.StaticEnv
 import StaticLS.StaticEnv.Options
 
@@ -68,9 +68,9 @@ handleDidSave = LSP.notificationHandler STextDocumentDidSave $ \_ -> pure ()
 
 handleWorkspaceSymbol :: Handlers (LspT c StaticLs)
 handleWorkspaceSymbol = LSP.requestHandler SWorkspaceSymbol $ \req res -> do
-  -- https://hackage.haskell.org/package/lsp-types-1.6.0.0/docs/Language-LSP-Types.html#t:WorkspaceSymbolParams
-  symbols <- lift (symbolInfo req._params._query)
-  res $ Right $ List symbols
+    -- https://hackage.haskell.org/package/lsp-types-1.6.0.0/docs/Language-LSP-Types.html#t:WorkspaceSymbolParams
+    symbols <- lift (symbolInfo req._params._query)
+    res $ Right $ List symbols
 
 initServer :: StaticEnvOptions -> LanguageContextEnv config -> Message 'Initialize -> IO (Either ResponseError (LspEnv config))
 initServer staticEnvOptions serverConfig _ = do

--- a/static-ls.cabal
+++ b/static-ls.cabal
@@ -41,6 +41,7 @@ library
       StaticLS.IDE.Definition
       StaticLS.IDE.Hover
       StaticLS.IDE.Hover.Info
+      StaticLS.IDE.Workspace.Symbol
       StaticLS.IDE.References
       StaticLS.Maybe
       StaticLS.Server


### PR DESCRIPTION
- Currently it only works on hiedb-0.4.4 (needs this [feature](https://github.com/wz1000/HieDb/pull/49)) in order for `AtPoint.defRowToSymbolInfo` work properly (which only converts definition that has `mods.src_file`
- demo: https://www.loom.com/share/df4a2fb6de0b4bf9841160a18b4c23ea?sid=5945c421-6b20-466d-88e3-e668fa48e220