### PR TITLE
Separate out mutable lsp information and immutable references to static sources of language information

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -75,3 +75,4 @@
 - ignore: {name: Use fmap}
 - ignore: {name: Redundant lambda}
 - ignore: {name: Use lambda-case}
+- ignore: {name: Use newtype instead of data}

--- a/app/App/Arguments.hs
+++ b/app/App/Arguments.hs
@@ -17,10 +17,9 @@ data PrgOptions = PrgOptions
     , showHelp :: Bool
     }
 
-{- | Run an argument parser but suppress invalid arguments (simply running the server instead)
-Helpful for people on emacs or whose default configurations from HLS pass in
-unsupported arguments to static-ls
--}
+-- | Run an argument parser but suppress invalid arguments (simply running the server instead)
+-- Helpful for people on emacs or whose default configurations from HLS pass in
+-- unsupported arguments to static-ls
 execArgParser :: IO StaticEnvOptions
 execArgParser =
     getArgs >>= handleParseResultWithSuppression . execParserPure defaultPrefs progParseInfo

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,1 @@
+haddock-style: single-line # 'signle-line' or 'multi-line', i.e., '--' vs. '{-'

--- a/src/StaticLS/FileEnv.hs
+++ b/src/StaticLS/FileEnv.hs
@@ -1,0 +1,21 @@
+module StaticLS.FileEnv where
+
+import AST.Haskell qualified as Haskell
+import Data.HashMap.Strict (HashMap)
+import Data.Text (Text)
+import Data.Text.Utf16.Rope.Mixed qualified as Rope
+import Language.LSP.Protocol.Types qualified as LSP
+import UnliftIO qualified as IORef
+
+-- | In memory representation of the current file system
+type FileEnv = IORef.IORef (HashMap LSP.NormalizedUri FileState)
+
+data FileState = FileState
+    { contents :: Rope.Rope
+    , contentsText :: Text
+    , tree :: Haskell.Haskell
+    }
+    deriving (Show)
+
+class HasFileEnv m where
+    getFileEnv :: m FileEnv

--- a/src/StaticLS/HIE.hs
+++ b/src/StaticLS/HIE.hs
@@ -25,9 +25,8 @@ import GHC.Iface.Ext.Types qualified as GHC
 import HieDb (pointCommand)
 import Language.LSP.Protocol.Types qualified as LSP
 
-{- | LSP Position is 0 indexed
-Note HieDbCoords are 1 indexed
--}
+-- | LSP Position is 0 indexed
+-- Note HieDbCoords are 1 indexed
 type HieDbCoords = (Int, Int)
 
 data UIntConversionException = UIntConversionException

--- a/src/StaticLS/HIE/File.hs
+++ b/src/StaticLS/HIE/File.hs
@@ -52,9 +52,8 @@ modToHieFile = exceptToMaybeT . getHieFile <=< modToHieFilePath
 modToSrcFile :: (HasStaticEnv m, MonadIO m) => GHC.ModuleName -> MaybeT m SrcFilePath
 modToSrcFile = hieFilePathToSrcFilePath <=< modToHieFilePath
 
-{- | Fetch a src file from an hie file, checking hiedb but falling back on a file manipulation method
-if not indexed
--}
+-- | Fetch a src file from an hie file, checking hiedb but falling back on a file manipulation method
+-- if not indexed
 srcFilePathToHieFilePath :: (HasStaticEnv m, MonadIO m) => SrcFilePath -> MaybeT m HieFilePath
 srcFilePathToHieFilePath srcPath =
     srcFilePathToHieFilePathFromFile srcPath
@@ -122,14 +121,13 @@ hieFilePathToSrcFilePathFromFile hiePath = do
     hieFile <- exceptToMaybeT $ getHieFile hiePath
     liftIO $ Dir.makeAbsolute hieFile.hie_hs_file
 
-{- | Retrieve a hie file path from a src path
-
-Substitutes the src directory with the hie directory and the src file extension with
-the hie file extension. Fragile, but works well in practice.
-
-Presently necessary because hiedb does not currently index the hs_src file location
-in the `mods` table
--}
+-- | Retrieve a hie file path from a src path
+--
+-- Substitutes the src directory with the hie directory and the src file extension with
+-- the hie file extension. Fragile, but works well in practice.
+--
+-- Presently necessary because hiedb does not currently index the hs_src file location
+-- in the `mods` table
 srcFilePathToHieFilePathFromFile :: (HasStaticEnv m, MonadIO m) => SrcFilePath -> MaybeT m HieFilePath
 srcFilePathToHieFilePathFromFile srcPath = do
     staticEnv <- getStaticEnv

--- a/src/StaticLS/HieDb.hs
+++ b/src/StaticLS/HieDb.hs
@@ -6,9 +6,8 @@ import Data.List (intercalate)
 import Database.SQLite.Simple
 import HieDb
 
-{- | Lookup 'HieModule' row from 'HieDb' given the path to the Haskell hie file
-A temporary function until this is supported in hiedb proper
--}
+-- | Lookup 'HieModule' row from 'HieDb' given the path to the Haskell hie file
+-- A temporary function until this is supported in hiedb proper
 lookupHieFileFromHie :: HieDb -> FilePath -> IO (Maybe HieModuleRow)
 lookupHieFileFromHie (getConn -> conn) fp = do
     files <- query conn "SELECT * FROM mods WHERE hieFile = ?" (Only fp)

--- a/src/StaticLS/IDE/CodeActions/Types.hs
+++ b/src/StaticLS/IDE/CodeActions/Types.hs
@@ -5,7 +5,7 @@ module StaticLS.IDE.CodeActions.Types where
 import Data.Aeson.TH
 import Data.Text
 import Language.LSP.Protocol.Types (Range (..), TextDocumentIdentifier (..))
-import StaticLS.StaticEnv
+import StaticLS.StaticLsEnv
 
 data Context = Context
     { textDocument :: !TextDocumentIdentifier
@@ -23,7 +23,7 @@ data CodeActionMessage = CodeActionMessage
 
 data GlobalCodeAction = GlobalCodeAction
     { name :: !Text
-    , run :: Context -> StaticLs (Maybe ())
+    , run :: Context -> StaticLsM (Maybe ())
     }
 
 $(deriveJSON defaultOptions ''CodeActionMessageKind)

--- a/src/StaticLS/IDE/Completion.hs
+++ b/src/StaticLS/IDE/Completion.hs
@@ -3,9 +3,9 @@
 module StaticLS.IDE.Completion where
 
 import Language.LSP.Protocol.Types qualified as LSP
-import StaticLS.StaticEnv
+import StaticLS.StaticLsEnv
 
-getCompletion :: LSP.Uri -> StaticLs ()
+getCompletion :: (HasStaticLsEnv m) => LSP.Uri -> m ()
 getCompletion uri = do
     fileState <- getFileState uri
     case fileState of

--- a/src/StaticLS/IDE/Definition.hs
+++ b/src/StaticLS/IDE/Definition.hs
@@ -112,10 +112,9 @@ getTypeDefinition tdi pos = do
 -- for the original code
 ---------------------------------------------------------------------
 
-{- | Given a 'Name' attempt to find the location where it is defined.
-See: https://hackage.haskell.org/package/ghcide-1.10.0.0/docs/src/Development.IDE.Spans.AtPoint.html#nameToLocation
-for original code
--}
+-- | Given a 'Name' attempt to find the location where it is defined.
+-- See: https://hackage.haskell.org/package/ghcide-1.10.0.0/docs/src/Development.IDE.Spans.AtPoint.html#nameToLocation
+-- for original code
 nameToLocation :: (HasCallStack, HasStaticEnv m, MonadIO m) => GHC.Name -> m [LSP.LocationLink]
 nameToLocation name = fmap (fromMaybe []) <$> runMaybeT $
     case GHC.nameSrcSpan name of

--- a/src/StaticLS/StaticLsEnv.hs
+++ b/src/StaticLS/StaticLsEnv.hs
@@ -1,0 +1,63 @@
+module StaticLS.StaticLsEnv where
+
+import AST.Haskell qualified as Haskell
+import Colog.Core.IO qualified as Colog
+import Control.Monad.Reader
+import Data.HashMap.Strict qualified as HashMap
+import Data.IORef qualified as IORef
+import Language.LSP.Protocol.Types qualified as LSP
+import StaticLS.FileEnv
+import StaticLS.Logger
+import StaticLS.StaticEnv
+import StaticLS.StaticEnv.Options
+
+-- | An environment for running a language server
+-- This differs from a `StaticEnv` in that it includes mutable information
+-- meant for language server specific functionality
+data StaticLsEnv = StaticLsEnv
+    { fileEnv :: FileEnv
+    , staticEnv :: StaticEnv
+    , logger :: Logger
+    }
+
+type StaticLsM = ReaderT StaticLsEnv IO
+
+class (HasFileEnv m, HasLogger m, HasStaticEnv m, MonadIO m) => HasStaticLsEnv m where
+    getStaticLsEnv :: m StaticLsEnv
+
+instance HasFileEnv StaticLsM where
+    getFileEnv = asks (.fileEnv)
+
+instance HasLogger StaticLsM where
+    getLogger = asks (.logger)
+
+instance HasStaticEnv StaticLsM where
+    getStaticEnv = asks (.staticEnv)
+
+initStaticLsEnv :: FilePath -> StaticEnvOptions -> Logger -> IO StaticLsEnv
+initStaticLsEnv wsRoot staticEnvOptions loggerToUse = do
+    staticEnv <- initStaticEnv wsRoot staticEnvOptions
+    fileEnv <- IORef.newIORef mempty
+    let logger = Colog.liftLogIO loggerToUse
+    pure $
+        StaticLsEnv
+            { staticEnv = staticEnv
+            , fileEnv = fileEnv
+            , logger = logger
+            }
+
+runStaticLsM :: StaticLsEnv -> StaticLsM a -> IO a
+runStaticLsM = flip runReaderT
+
+getHaskell :: (HasFileEnv m, MonadIO m) => LSP.Uri -> m (Maybe Haskell.Haskell)
+getHaskell uri = do
+    fileState <- getFileState uri
+    pure $ (.tree) <$> fileState
+
+getFileState :: (HasFileEnv m, MonadIO m) => LSP.Uri -> m (Maybe FileState)
+getFileState uri = do
+    uri <- pure $ LSP.toNormalizedUri uri
+    fileEnv <- getFileEnv
+    fileStates <- liftIO $ IORef.readIORef fileEnv
+    let fileState = HashMap.lookup uri fileStates
+    pure fileState

--- a/static-ls.cabal
+++ b/static-ls.cabal
@@ -35,6 +35,7 @@ flag dev
 library
   exposed-modules:
       StaticLS.Except
+      StaticLS.FileEnv
       StaticLS.FilePath
       StaticLS.HI
       StaticLS.HI.File
@@ -58,6 +59,7 @@ library
       StaticLS.SrcFiles
       StaticLS.StaticEnv
       StaticLS.StaticEnv.Options
+      StaticLS.StaticLsEnv
       StaticLS.Utils
   other-modules:
       Paths_static_ls

--- a/test/StaticLS/HI/FileSpec.hs
+++ b/test/StaticLS/HI/FileSpec.hs
@@ -17,7 +17,7 @@ spec = do
             it "returns a valid hi file when called on a src file" $ do
                 staticEnv <- Test.initStaticEnv
                 hiFile <-
-                    runStaticLs staticEnv $
+                    runStaticEnv staticEnv $
                         runMaybeT $
                             srcFilePathToHiFilePath "test/TestData/Mod1.hs"
                 let relativeHiFile = makeRelative staticEnv.wsRoot <$> hiFile
@@ -29,7 +29,7 @@ spec = do
             it "returns a valid hi file when called on a test/ file" $ do
                 staticEnv <- Test.initStaticEnv
                 hiFile <-
-                    runStaticLs staticEnv $
+                    runStaticEnv staticEnv $
                         runMaybeT $
                             srcFilePathToHiFilePath "test/TestData/Mod1.hs"
                 let relativeHiFile = makeRelative staticEnv.wsRoot <$> hiFile

--- a/test/StaticLS/HIE/FileSpec.hs
+++ b/test/StaticLS/HIE/FileSpec.hs
@@ -18,7 +18,7 @@ spec = do
             it "returns a valid hie file when called on a src file" $ do
                 staticEnv <- Test.initStaticEnv
                 hieFile <-
-                    runStaticLs staticEnv $
+                    runStaticEnv staticEnv $
                         runMaybeT $
                             srcFilePathToHieFilePath "src/StaticLS/HIE/File.hs"
                 let relativeHieFile = makeRelative staticEnv.wsRoot <$> hieFile
@@ -30,7 +30,7 @@ spec = do
             it "returns a valid hie file when called on a test/ file" $ do
                 staticEnv <- Test.initStaticEnv
                 hieFile <-
-                    runStaticLs staticEnv $
+                    runStaticEnv staticEnv $
                         runMaybeT $
                             srcFilePathToHieFilePath "test/TestData/Mod1.hs"
                 let relativeHieFile = makeRelative staticEnv.wsRoot <$> hieFile
@@ -43,7 +43,7 @@ spec = do
         it "Returns a valid hie file" $ do
             staticEnv <- Test.initStaticEnv
             hieFile <-
-                runStaticLs staticEnv $
+                runStaticEnv staticEnv $
                     runExceptT $
                         getHieFile "test/TestData/.hiefiles/TestData/Mod1.hie"
             _ <- Test.assertRight "expected succesful read" hieFile
@@ -59,7 +59,7 @@ spec = do
                         }
             staticEnv <- Test.initStaticEnvOpts emptyOpts
             hieFile <-
-                runStaticLs staticEnv $
+                runStaticEnv staticEnv $
                     runExceptT $
                         getHieFile "./test/TestData/Mod1.hs"
             _ <- Test.assertLeft "expected failure" hieFile
@@ -75,7 +75,7 @@ spec = do
                         }
             staticEnv <- Test.initStaticEnvOpts emptyOpts
             hieFile <-
-                runStaticLs staticEnv $
+                runStaticEnv staticEnv $
                     runExceptT $
                         getHieFile ""
             _ <- Test.assertLeft "expected failure" hieFile

--- a/test/StaticLS/HISpec.hs
+++ b/test/StaticLS/HISpec.hs
@@ -23,7 +23,7 @@ spec = do
             fnLocation <- myFunDefLocation
             let position = lspPositionToHieDbCoords fnLocation._range._start
                 names = namesAtPoint hieFile position
-                expectedDocs = ["Lsp Position line: 11,  character: 0\nanother line of comments\n"]
+                expectedDocs = ["Lsp Position line: 10,  character: 0\n another line of comments"]
                 readDocs = renderNameDocs <$> getDocsBatch names modiface
 
             _ <- readDocs `shouldBe` expectedDocs

--- a/test/StaticLS/IDE/DefinitionSpec.hs
+++ b/test/StaticLS/IDE/DefinitionSpec.hs
@@ -14,7 +14,7 @@ spec =
         describe "All available sources" $ do
             it "retrieves the myFun definition from a different module" $ do
                 staticEnv <- Test.initStaticEnv
-                defnLinks <- runStaticLs staticEnv $ uncurry getDefinition Test.myFunRef1TdiAndPosition
+                defnLinks <- runStaticEnv staticEnv $ uncurry getDefinition Test.myFunRef1TdiAndPosition
                 defnLink <- Test.assertHead "no definition link found" defnLinks
                 expectedDefnLink <- Test.myFunDefDefinitionLink
                 defnLink `shouldBe` expectedDefnLink
@@ -30,7 +30,7 @@ spec =
                                 , optionHiFilesPath = "test/TestData/.hifiles"
                                 }
                     staticEnv <- Test.initStaticEnvOpts emptyOpts
-                    defnLinks <- runStaticLs staticEnv $ uncurry getDefinition Test.myFunRef1TdiAndPosition
+                    defnLinks <- runStaticEnv staticEnv $ uncurry getDefinition Test.myFunRef1TdiAndPosition
                     defnLink <- Test.assertHead "no definition link found" defnLinks
                     expectedDefnLink <- Test.myFunDefDefinitionLink
                     defnLink `shouldBe` expectedDefnLink
@@ -44,7 +44,7 @@ spec =
                                 , optionHiFilesPath = "test/TestData/.hifiles"
                                 }
                     staticEnv <- Test.initStaticEnvOpts emptyOpts
-                    defnLinks <- runStaticLs staticEnv $ uncurry getDefinition Test.myFunRef1TdiAndPosition
+                    defnLinks <- runStaticEnv staticEnv $ uncurry getDefinition Test.myFunRef1TdiAndPosition
                     defnLink <- Test.assertHead "no definition link found" defnLinks
                     expectedDefnLink <- Test.myFunDefDefinitionLink
                     defnLink `shouldBe` expectedDefnLink
@@ -58,5 +58,5 @@ spec =
                             , optionHiFilesPath = ""
                             }
                 staticEnv <- Test.initStaticEnvOpts emptyOpts
-                locs <- runStaticLs staticEnv $ uncurry getDefinition Test.myFunRef1TdiAndPosition
+                locs <- runStaticEnv staticEnv $ uncurry getDefinition Test.myFunRef1TdiAndPosition
                 locs `shouldBe` []

--- a/test/StaticLS/IDE/HoverSpec.hs
+++ b/test/StaticLS/IDE/HoverSpec.hs
@@ -1,7 +1,7 @@
 module StaticLS.IDE.HoverSpec where
 
 import StaticLS.IDE.Hover
-import StaticLS.StaticEnv
+import StaticLS.StaticLsEnv
 import Test.Hspec
 import TestImport qualified as Test
 import TestImport.Assert qualified as Test
@@ -12,7 +12,7 @@ spec =
     describe "Correctly retrieves hover information" $ do
         describe "All available sources" $ do
             it "retrieves the myFun definition from a different module" $ do
-                staticEnv <- Test.initStaticEnv
-                mHoverInfo <- runStaticLs staticEnv $ uncurry retrieveHover Test.myFunRef1TdiAndPosition
+                staticLsEnv <- Test.initStaticLsEnv
+                mHoverInfo <- runStaticLsM staticLsEnv $ uncurry retrieveHover Test.myFunRef1TdiAndPosition
                 _ <- Test.assertJust "no hover info found" mHoverInfo
                 pure ()

--- a/test/TestData/Mod2.hs
+++ b/test/TestData/Mod2.hs
@@ -1,8 +1,7 @@
 module TestData.Mod2 where
 
-{- | Lsp Position line: 11,  character: 0
-another line of comments
--}
+-- | Lsp Position line: 10,  character: 0
+-- another line of comments
 myFun ::
     -- | First int
     Int ->

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -2,13 +2,19 @@ module TestImport where
 
 import StaticLS.Logger
 import StaticLS.StaticEnv as StaticEnv
-import StaticLS.StaticEnv.Options as StaticEnv
+import StaticLS.StaticEnv.Options as Options
+import StaticLS.StaticLsEnv as StaticLsEnv
 import System.Directory (makeAbsolute)
+
+initStaticLsEnv :: IO StaticLsEnv
+initStaticLsEnv = do
+    wsRoot <- makeAbsolute "."
+    StaticLsEnv.initStaticLsEnv wsRoot defaultTestStaticEnvOptions noOpLogger
 
 initStaticEnv :: IO StaticEnv
 initStaticEnv = do
     wsRoot <- makeAbsolute "."
-    StaticEnv.initStaticEnv wsRoot defaultTestStaticEnvOptions noOpLogger
+    StaticEnv.initStaticEnv wsRoot defaultTestStaticEnvOptions
 
 testHieDir :: FilePath
 testHieDir = "test/TestData/.hiefiles"
@@ -20,7 +26,7 @@ testHieDbDir :: FilePath
 testHieDbDir = "test/TestData/.hiedb"
 
 testSrcDirs :: [FilePath]
-testSrcDirs = StaticEnv.defaultSrcDirs
+testSrcDirs = Options.defaultSrcDirs
 
 defaultTestStaticEnvOptions :: StaticEnvOptions
 defaultTestStaticEnvOptions =
@@ -34,4 +40,9 @@ defaultTestStaticEnvOptions =
 initStaticEnvOpts :: StaticEnvOptions -> IO StaticEnv
 initStaticEnvOpts options = do
     wsRoot <- makeAbsolute "."
-    StaticEnv.initStaticEnv wsRoot options noOpLogger
+    StaticEnv.initStaticEnv wsRoot options
+
+initStaticLsEnvOpts :: StaticEnvOptions -> IO StaticLsEnv
+initStaticLsEnvOpts options = do
+    wsRoot <- makeAbsolute "."
+    StaticLsEnv.initStaticLsEnv wsRoot options noOpLogger

--- a/test/TestImport/TestData.hs
+++ b/test/TestImport/TestData.hs
@@ -37,12 +37,12 @@ myFunDefLocation = do
                 LSP.Range
                     { _start =
                         LSP.Position
-                            { LSP._line = 11
+                            { LSP._line = 10
                             , LSP._character = 0
                             }
                     , LSP._end =
                         LSP.Position
-                            { LSP._line = 11
+                            { LSP._line = 10
                             , LSP._character = 5
                             }
                     }


### PR DESCRIPTION
This PR refactors the mutable file system and logger state out of `StaticEnv` into `StaticLsEnv`. Most functions should ideally depend on the minimal set of information required

Prs https://github.com/josephsumabat/static-ls/pull/36 and https://github.com/josephsumabat/static-ls/pull/37
introduced logging and the virtual file system to static-ls. While this information is undoubtedly useful, I would like to maintain explicit separation between immutable references to static source of language information and mutable information used by the language server portion

The purpose behind this is to eventually be able to expose static-ls's "language intelligence" capabilities as a library with minimal dependencies on the language server protocol side as well as separate out the concerns.

