### PR TITLE
Disallow find refs on template haskell splices

### DIFF
--- a/src/StaticLS/HieView/View.hs
+++ b/src/StaticLS/HieView/View.hs
@@ -204,8 +204,7 @@ viewAst hieAst =
 viewSourcedNodeInfo :: GHC.SourcedNodeInfo GHC.TypeIndex -> SourcedNodeInfo TypeIndex
 viewSourcedNodeInfo (GHC.SourcedNodeInfo sourcedNodeInfo) =
   Map.fromList
-    ( ( bimap viewNodeOrigin viewNodeInfo
-      )
+    ( (bimap viewNodeOrigin viewNodeInfo)
         <$> (Map.toList sourcedNodeInfo)
     )
 

--- a/src/StaticLS/Hir.hs
+++ b/src/StaticLS/Hir.hs
@@ -21,6 +21,8 @@ data NameSpace
   | NameSpacePattern
   deriving (Show)
 
+type ThSplice = Haskell.TopSplice :+ Haskell.Splice
+
 data Name = Name
   { node :: !DynNode
   , isOperator :: !Bool

--- a/src/StaticLS/IDE/CodeActions.hs
+++ b/src/StaticLS/IDE/CodeActions.hs
@@ -7,7 +7,6 @@ module StaticLS.IDE.CodeActions where
 
 import Data.LineCol (LineCol (..))
 import Data.Path (AbsPath)
-import Data.Pos (Pos (..))
 import Data.Rope qualified as Rope
 import StaticLS.IDE.CodeActions.AddTypeSig qualified as AddTypeSig
 import StaticLS.IDE.CodeActions.AutoImport qualified as AutoImport

--- a/test/SpecHook.hs
+++ b/test/SpecHook.hs
@@ -11,8 +11,7 @@ import Prelude
 hook :: Spec -> Spec
 hook = do
   beforeAll
-    ( removeIfExists testHieDbDir >> indexHieFiles >> removeIfExists testHieDbDir
-    )
+    (removeIfExists testHieDbDir >> indexHieFiles >> removeIfExists testHieDbDir)
  where
   removeIfExists :: FilePath -> IO ()
   removeIfExists fileName = removeFile fileName `catch` handleExists


### PR DESCRIPTION
Template Haskell results in way too many references being loaded causing the server to hang