### PR TITLE
Disable format handler temporarily until configuration is available

### DIFF
--- a/src/StaticLS/Hir/Print.hs
+++ b/src/StaticLS/Hir/Print.hs
@@ -15,20 +15,23 @@ printModuleName :: ModuleName -> TL.Text
 printModuleName name = TL.fromStrict name.mod.text
 
 printQualified :: Qualified -> TL.Text
-printQualified (Qualified {mod, name}) = case mod of
-  Nothing -> printName name
-  Just modName -> TL.concat [printModuleName modName, ".", printName name]
+printQualified (Qualified {mod, name}) =
+  case mod of
+    Nothing -> printName name
+    Just modName -> TL.concat [printModuleName modName, ".", printName name]
 
 printExportChildren :: ExportChildren -> TL.Text
-printExportChildren export = case export of
-  ExportAllChildren -> ".."
-  ExportChild namespace name -> printQualified name
+printExportChildren export =
+  case export of
+    ExportAllChildren -> ".."
+    ExportChild _namespace name -> printQualified name
 
 printExportItem :: ExportItem -> TL.Text
-printExportItem export = case export of
-  ExportItem {namespace, name, children} ->
-    printQualified name <> TL.intercalate ", " (map printExportChildren children)
-  ExportModuleItem mod -> "module " <> printModuleName mod
+printExportItem export =
+  case export of
+    ExportItem {namespace = _namespace, name, children} ->
+      printQualified name <> TL.intercalate ", " (map printExportChildren children)
+    ExportModuleItem mod -> "module " <> printModuleName mod
 
 printExportItems :: [ExportItem] -> TL.Text
 printExportItems exports = TL.intercalate ",\n" (map printExportItem exports)

--- a/src/StaticLS/Server.hs
+++ b/src/StaticLS/Server.hs
@@ -192,8 +192,9 @@ serverDef argOptions logger = do
               , handleResolveCodeAction
               , handleDocumentSymbols
               , handleCompletion
-              , handleFormat
-              , handleCompletionItemResolve
+              , -- Currently disabled until we support configuration for the formatter
+                -- , handleFormat
+                handleCompletionItemResolve
               ]
       , interpretHandler = \env -> Iso (LSP.runLspT env) liftIO
       , options = lspOptions


### PR DESCRIPTION
The current formatter assumes fourmolu but we should make this configurable instead

Includes some minor formatting changes