### PR TITLE
Compatibility with ghc-9.10.1

### DIFF
--- a/src/StaticLS/HI.hs
+++ b/src/StaticLS/HI.hs
@@ -8,6 +8,7 @@ module StaticLS.HI (
 )
 where
 
+import Data.Foldable
 import Data.IntMap qualified as IntMap
 import Data.Map qualified as Map
 import Data.Maybe
@@ -78,7 +79,7 @@ uniqNameMapToMap :: GHC.UniqMap GHC.Name v -> Map.Map String v
 uniqNameMapToMap =
   Map.fromList
     . fmap stringifyNameKeys
-    . IntMap.elems
+    . toList
     . GHC.ufmToIntMap
     . getUniqMap
  where

--- a/src/StaticLS/HieView/Name.hs
+++ b/src/StaticLS/HieView/Name.hs
@@ -22,6 +22,7 @@ import Data.Hashable (Hashable (..))
 import Data.LineColRange (LineColRange)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Word (Word64)
 import GHC.Plugins qualified as GHC
 import GHC.Types.Unique qualified
 import StaticLS.HieView.InternStr (InternStr)
@@ -32,7 +33,7 @@ newtype ModuleName = ModuleName {name :: GHC.ModuleName}
   deriving (Show, Eq)
 
 instance Hashable ModuleName where
-  hashWithSalt salt = hashWithSalt @Int salt . GHC.Types.Unique.getKey . GHC.getUnique . (.name)
+  hashWithSalt salt = hashWithSalt @Word64 salt . fromIntegral . GHC.Types.Unique.getKey . GHC.getUnique . (.name)
 
 moduleNameToInternStr :: ModuleName -> InternStr
 moduleNameToInternStr = InternStr.fromGHCFastString . GHC.moduleNameFS . (.name)
@@ -47,7 +48,7 @@ newtype Name = Name {name :: GHC.Name}
   deriving (Eq)
 
 instance Hashable Name where
-  hashWithSalt salt = hashWithSalt @Int salt . GHC.Types.Unique.getKey . GHC.nameUnique . (.name)
+  hashWithSalt salt = hashWithSalt @Word64 salt . fromIntegral . GHC.Types.Unique.getKey . GHC.nameUnique . (.name)
 
 fromGHCName :: GHC.Name -> Name
 fromGHCName = Name


### PR DESCRIPTION
1. By using a fromIntegral cast we avoid exposing the actual representation. GHC-9.10.1 changes Uniques to contain Word64.
2. Instead of assuming ufmToIntMap returns an IntMap (as the name suggest) expect it to return something Foldable for which toList works.

This allows us to support ghc-9.10.1 without any conditionals.