### PR TITLE
Code action deletions to assist fixes

### DIFF
--- a/src/StaticLS/Handlers.hs
+++ b/src/StaticLS/Handlers.hs
@@ -197,6 +197,7 @@ handleSetTrace = LSP.notificationHandler LSP.SMethod_SetTrace $ \_ -> pure ()
 
 handleCodeAction :: Handlers (LspT c StaticLsM)
 handleCodeAction = LSP.requestHandler LSP.SMethod_TextDocumentCodeAction $ \req res -> do
+  _ <- lift $ logInfo "handleCodeAction"
   let params = req._params
   let tdi = params._textDocument
   path <- ProtoLSP.uriToAbsPath tdi._uri

--- a/src/StaticLS/IDE/CodeActions/RemoveRedundantImports.hs
+++ b/src/StaticLS/IDE/CodeActions/RemoveRedundantImports.hs
@@ -49,7 +49,7 @@ codeAction CodeActionContext {path} = do
   let localRedundantImportDiagnostics = filter (isDeletionInFile path) deletionInfos
   let globalAssist = deletionsToAssist "Remove redundant imports in project" globalRedundantImportDiagnostics
   let localAssist = deletionsToAssist "Remove redundant imports in file" localRedundantImportDiagnostics
-  pure [localAssist, globalAssist]
+  pure $ catMaybes [localAssist, globalAssist]
 
 getDiagnostics :: StaticLsM [Diagnostic]
 getDiagnostics = do
@@ -106,12 +106,13 @@ isFileSaved absPath = do
     Just src -> src == contentsText
     Nothing -> False
 
-deletionsToAssist :: Text.Text -> [DeletionInfo] -> Assist
+deletionsToAssist :: Text.Text -> [DeletionInfo] -> Maybe Assist
 deletionsToAssist message deletions = do
   let numFixes = length deletions
-  let fixCase = if numFixes == 1 then "fix" else "fixes"
-  let message' = message <> " (" <> (Text.pack . show) numFixes <> " " <> fixCase <> ")"
-  mkAssist message' $ actOnDeletions deletions
+  if numFixes == 0 then Nothing else do
+    let fixCase = if numFixes == 1 then "fix" else "fixes"
+    let message' = message <> " (" <> (Text.pack . show) numFixes <> " " <> fixCase <> ")"
+    Just $ mkAssist message' $ actOnDeletions deletions
 
 actOnDeletions :: [DeletionInfo] -> SourceEdit
 actOnDeletions deletionInfos = do


### PR DESCRIPTION
- **Add logging for handleCodeAction**  
- **Do not report an Assist when number of fixes is 0**  

Some context. When using something like [lightbulb](https://github.com/kosayoda/nvim-lightbulb) which shows a sign, whenever a _textDocument/codeAction_ is available at the current cursor position, without this change there is a code action reported for every line even where there are 0 fixes.

I am not 100% sure if this would be considered a bug, but, I believe if there are no fixes, there should be no code actions reported? Feel free to close the issue, if you consider this a no fix or not a bug.

Thank you very much for your work on `static-ls`.