### PR TITLE
Fix for inlay hint alignment bug

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Configure the build
         run: |
           cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal update
           cabal build all --dry-run
         # The last step generates dist-newstyle/cache/plan.json for the cache key.
 

--- a/cabal.project
+++ b/cabal.project
@@ -5,8 +5,6 @@ packages:
     -- ../tree-sitter-simple/tree-sitter-ast
     -- ../tree-sitter-simple/haskell-ast
 
-allow-newer: text-rope
-
 source-repository-package
     type: git
     location: https://github.com/josephsumabat/tree-sitter-simple.git

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,8 @@ packages:
     -- ../tree-sitter-simple/tree-sitter-ast
     -- ../tree-sitter-simple/haskell-ast
 
+allow-newer: text-rope
+
 source-repository-package
     type: git
     location: https://github.com/josephsumabat/tree-sitter-simple.git

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -47,7 +47,7 @@ in
         }) {};
 
         hiedb = self.haskell.lib.dontCheck (haskellSuper.callHackage "hiedb" "0.6.0.1" {});
-        text-rope = haskellSuper.callHackage "text-rope" "0.2" {};
+        text-rope = haskellSuper.callHackage "text-rope" "0.3" {};
 
         lsp-types = haskellSuper.callHackage "lsp-types" "2.3.0.0" {};
         lsp = haskellSuper.callHackage "lsp" "2.7.0.0" {};

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ dependencies:
   - unliftio-core >= 0.2.1 && < 0.3
   - unliftio >= 0.2.1 && < 0.3
   - aeson >=2 && <2.3
-  - text-rope == 0.2
+  - text-rope == 0.3
   - co-log-core >= 0.3 && < 0.4
   - tree-sitter-simple
   - tree-sitter-haskell

--- a/src/Data/Rope.hs
+++ b/src/Data/Rope.hs
@@ -1,6 +1,7 @@
 module Data.Rope (
   Rope,
   fromTextRope,
+  fromTextRopeL,
   toTextRope,
   fromText,
   toText,
@@ -33,48 +34,52 @@ import Data.Pos (Pos (..))
 import Data.Range (Range (..))
 import Data.String (IsString)
 import Data.Text (Text)
-import Data.Text.Lines as Rope (Position (..))
-import Data.Text.Utf16.Rope.Mixed qualified as Rope
+import Data.Text.Lines qualified as RopeL (Position (..))
+import Data.Text.Utf16.Rope.Mixed qualified as Rope16
+import Data.Text.Utf8.Rope qualified as Rope8
 import Prelude hiding (getLine, length, splitAt)
 
-newtype Rope = Rope {rope :: Rope.Rope}
+newtype Rope = Rope {rope :: Rope8.Rope}
   deriving (Show, Eq, Ord, Semigroup, Monoid, IsString)
 
 empty :: Rope
 empty = Rope mempty
 
-fromTextRope :: Rope.Rope -> Rope
+fromTextRope :: Rope8.Rope -> Rope
 fromTextRope = Rope
 
-toTextRope :: Rope -> Rope.Rope
+fromTextRopeL :: Rope16.Rope -> Rope
+fromTextRopeL = fromText . Rope16.toText
+
+toTextRope :: Rope -> Rope8.Rope
 toTextRope = (.rope)
 
 fromText :: Text -> Rope
-fromText = Rope . Rope.fromText
+fromText = Rope . Rope8.fromText
 
 toText :: Rope -> Text
-toText = Rope.toText . (.rope)
+toText = Rope8.toText . (.rope)
 
 length :: Rope -> Int
-length = fromIntegral . Rope.charLength . (.rope)
+length = fromIntegral . Rope8.length . (.rope)
 
 posToLineCol :: Rope -> Pos -> LineCol
 posToLineCol r (Pos pos) =
   LineCol
-    (Pos (fromIntegral (Rope.posLine ropePos)))
-    (Pos (fromIntegral (Rope.posColumn ropePos)))
+    (Pos (fromIntegral (Rope8.posLine ropePos)))
+    (Pos (fromIntegral (Rope8.posColumn ropePos)))
  where
-  ropePos = Rope.charLengthAsPosition beforePos
+  ropePos = Rope8.lengthAsPosition beforePos
   rope = r.rope
-  (beforePos, _afterPos) = Rope.charSplitAt (fromIntegral pos) rope
+  Just (beforePos, _afterPos) = Rope8.splitAt (fromIntegral pos) rope
 
 lineColToPos :: Rope -> LineCol -> Pos
 lineColToPos r (LineCol (Pos line) (Pos col)) =
-  Pos (fromIntegral (Rope.charLength beforeLineCol))
+  Pos (fromIntegral (Rope8.length beforeLineCol))
  where
-  (beforeLineCol, _) = Rope.charSplitAtPosition ropePos rope
+  Just (beforeLineCol, _) = Rope8.splitAtPosition ropePos rope
   rope = r.rope
-  ropePos = Rope.Position (fromIntegral line) (fromIntegral col)
+  ropePos = Rope8.Position (fromIntegral line) (fromIntegral col)
 
 rangeToLineColRange :: Rope -> Range -> LineColRange
 rangeToLineColRange r (Range start end) =
@@ -87,10 +92,10 @@ lineColRangeToRange r (LineColRange start end) =
 
 change :: Change -> Rope -> Rope
 change Change {insert, delete} (Rope rope) =
-  Rope (beforeStart <> Rope.fromText insert <> afterEnd)
+  Rope (beforeStart <> Rope8.fromText insert <> afterEnd)
  where
-  (beforeStart, afterStart) = Rope.charSplitAt (fromIntegral delete.start.pos) rope
-  (_, afterEnd) = Rope.charSplitAt (fromIntegral (delete.end.pos - delete.start.pos)) afterStart
+  Just (beforeStart, afterStart) = Rope8.splitAt (fromIntegral delete.start.pos) rope
+  Just (_, afterEnd) = Rope8.splitAt (fromIntegral (delete.end.pos - delete.start.pos)) afterStart
 
 edit :: Edit -> Rope -> Rope
 -- apply changes in reverse order
@@ -99,15 +104,15 @@ edit (reverse . Edit.getChanges -> changes) rope = Foldable.foldl' (flip change)
 splitAt :: Pos -> Rope -> (Rope, Rope)
 splitAt (Pos pos) (Rope rope) = (Rope before, Rope after)
  where
-  (before, after) = Rope.charSplitAt (fromIntegral pos) rope
+  Just (before, after) = Rope8.splitAt (fromIntegral pos) rope
 
 -- TODO: return a maybe
 splitAtLineCol :: LineCol -> Rope -> (Rope, Rope)
 splitAtLineCol (LineCol (Pos line) (Pos col)) (Rope rope) = (Rope before, Rope after)
  where
-  (before, after) =
-    Rope.charSplitAtPosition
-      ( Rope.Position
+  Just (before, after) =
+    Rope8.splitAtPosition
+      ( Rope8.Position
           { posLine = (fromIntegral line)
           , posColumn = (fromIntegral col)
           }
@@ -116,18 +121,27 @@ splitAtLineCol (LineCol (Pos line) (Pos col)) (Rope rope) = (Rope before, Rope a
 
 indexRange :: Rope -> Range -> Maybe Rope
 indexRange (Rope r) (Range (Pos start) (Pos end))
-  | start < fromIntegral (Rope.charLength r) && end < fromIntegral (Rope.charLength r) =
+  | start
+      < fromIntegral
+        ( Rope8.length
+            r
+        )
+      && end
+        < fromIntegral
+          ( Rope8.length
+              r
+          ) =
       Just (Rope indexed)
   | otherwise = Nothing
  where
-  (_beforeStart, afterStart) = Rope.charSplitAt (fromIntegral start) r
-  (indexed, _) = Rope.charSplitAt (fromIntegral (end - start)) afterStart
+  Just (_beforeStart, afterStart) = Rope8.splitAt (fromIntegral start) r
+  Just (indexed, _) = Rope8.splitAt (fromIntegral (end - start)) afterStart
 
 isValidLineCol :: Rope -> LineCol -> Bool
 isValidLineCol r (LineCol (Pos line) (Pos col)) =
   line >= 0
     && col >= 0
-    && line < fromIntegral @Word @Int (Rope.lengthInLines rope)
+    && line < fromIntegral @Word @Int (Rope8.lengthInLines rope)
     && col < length (uncheckedGetLine r (Pos line))
  where
   rope = r.rope
@@ -137,22 +151,22 @@ isValidLineColEnd :: Rope -> LineCol -> Bool
 isValidLineColEnd r (LineCol (Pos line) (Pos col)) =
   line >= 0
     && col >= 0
-    && line < fromIntegral @Word @Int (Rope.lengthInLines rope)
+    && line < fromIntegral @Word @Int (Rope8.lengthInLines rope)
     && col <= length (uncheckedGetLine r (Pos line))
  where
   rope = r.rope
 linesLength :: Rope -> Int
-linesLength (Rope rope) = fromIntegral . Rope.lengthInLines $ rope
+linesLength (Rope rope) = fromIntegral . Rope8.lengthInLines $ rope
 
 -- | get the line, including the newline!
 getLine :: Rope -> Pos -> Maybe Rope
 getLine rope line
-  | line.pos < fromIntegral (Rope.lengthInLines rope.rope) = Just $! uncheckedGetLine rope line
+  | line.pos < fromIntegral (Rope8.lengthInLines rope.rope) = Just $! uncheckedGetLine rope line
   | otherwise = Nothing
 
 uncheckedGetLine :: Rope -> Pos -> Rope
 uncheckedGetLine (Rope rope) (Pos line) =
   Rope theLine
  where
-  (_before, after) = Rope.splitAtLine (fromIntegral line) rope
-  (theLine, _) = Rope.splitAtLine 1 after
+  (_before, after) = Rope8.splitAtLine (fromIntegral line) rope
+  (theLine, _) = Rope8.splitAtLine 1 after

--- a/src/Data/Rope.hs
+++ b/src/Data/Rope.hs
@@ -34,7 +34,6 @@ import Data.Pos (Pos (..))
 import Data.Range (Range (..))
 import Data.String (IsString)
 import Data.Text (Text)
-import Data.Text.Lines qualified as RopeL (Position (..))
 import Data.Text.Utf16.Rope.Mixed qualified as Rope16
 import Data.Text.Utf8.Rope qualified as Rope8
 import Prelude hiding (getLine, length, splitAt)

--- a/src/StaticLS/Handlers.hs
+++ b/src/StaticLS/Handlers.hs
@@ -12,7 +12,6 @@ import Data.Path qualified as Path
 import Data.Rope qualified as Rope
 import Data.Text qualified as T
 import Data.Text.IO qualified as T.IO
-import Data.Text.Utf8.Rope qualified as Rope8
 import Language.LSP.Diagnostics qualified as LSP
 import Language.LSP.Protocol.Lens qualified as LSP hiding (publishDiagnostics)
 import Language.LSP.Protocol.Message qualified as LSP

--- a/src/StaticLS/Handlers.hs
+++ b/src/StaticLS/Handlers.hs
@@ -12,6 +12,7 @@ import Data.Path qualified as Path
 import Data.Rope qualified as Rope
 import Data.Text qualified as T
 import Data.Text.IO qualified as T.IO
+import Data.Text.Utf8.Rope qualified as Rope8
 import Language.LSP.Diagnostics qualified as LSP
 import Language.LSP.Protocol.Lens qualified as LSP hiding (publishDiagnostics)
 import Language.LSP.Protocol.Message qualified as LSP
@@ -163,7 +164,7 @@ updateFileStateForUri uri = do
   virtualFile <- LSP.getVirtualFile normalizedUri
   virtualFile <- isJustOrThrowS "no virtual file" virtualFile
   path <- ProtoLSP.uriToAbsPath uri
-  lift $ IDE.onNewSource path (Rope.fromTextRope virtualFile._file_text)
+  lift $ IDE.onNewSource path (Rope.fromTextRopeL virtualFile._file_text)
   pure ()
 
 handleDidChange :: Handlers (LspT c StaticLsM)

--- a/src/StaticLS/IDE/InlayHints.hs
+++ b/src/StaticLS/IDE/InlayHints.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 
-{-# HLINT ignore "Use camelCase" #-}
+{- HLINT ignore "Use camelCase" -}
 
 module StaticLS.IDE.InlayHints (
   getInlayHints,

--- a/static-ls.cabal
+++ b/static-ls.cabal
@@ -85,7 +85,7 @@ library
     , template-haskell >=2.19.0 && <2.23
     , text >=2.0.1 && <2.2
     , text-range
-    , text-rope ==0.2
+    , text-rope ==0.3
     , time >=1.0 && <2.0
     , transformers >=0.5.6.2 && <0.7
     , tree-sitter-ast
@@ -235,7 +235,7 @@ executable print-hie
     , template-haskell >=2.19.0 && <2.23
     , text >=2.0.1 && <2.2
     , text-range
-    , text-rope ==0.2
+    , text-rope ==0.3
     , time >=1.0 && <2.0
     , transformers >=0.5.6.2 && <0.7
     , tree-sitter-ast
@@ -304,7 +304,7 @@ executable static-ls
     , template-haskell >=2.19.0 && <2.23
     , text >=2.0.1 && <2.2
     , text-range
-    , text-rope ==0.2
+    , text-rope ==0.3
     , time >=1.0 && <2.0
     , transformers >=0.5.6.2 && <0.7
     , tree-sitter-ast
@@ -390,7 +390,7 @@ test-suite expect_tests
     , template-haskell >=2.19.0 && <2.23
     , text >=2.0.1 && <2.2
     , text-range
-    , text-rope ==0.2
+    , text-rope ==0.3
     , time >=1.0 && <2.0
     , transformers >=0.5.6.2 && <0.7
     , tree-sitter-ast
@@ -462,7 +462,7 @@ test-suite static-ls-test
     , template-haskell >=2.19.0 && <2.23
     , text >=2.0.1 && <2.2
     , text-range
-    , text-rope ==0.2
+    , text-rope ==0.3
     , time >=1.0 && <2.0
     , transformers >=0.5.6.2 && <0.7
     , tree-sitter-ast

--- a/test/StaticLS/HIE/FileSpec.hs
+++ b/test/StaticLS/HIE/FileSpec.hs
@@ -58,6 +58,8 @@ spec = do
             , optionHieFilesPath = ""
             , optionSrcDirs = []
             , optionHiFilesPath = ""
+            , provideInlays = True
+            , inlayLengthCap = Just 32
             }
 
     check

--- a/test/StaticLS/IDE/DefinitionSpec.hs
+++ b/test/StaticLS/IDE/DefinitionSpec.hs
@@ -45,6 +45,8 @@ spec = do
           , optionHieFilesPath = "test/TestData/.hiefiles"
           , optionSrcDirs = defaultSrcDirs
           , optionHiFilesPath = "test/TestData/.hifiles"
+          , provideInlays = True
+          , inlayLengthCap = Just 32
           }
         Test.myFunRef1TdiAndPosition
         (pure @[] <$> Test.myFunDefLocation)
@@ -56,6 +58,8 @@ spec = do
           , optionHieFilesPath = ""
           , optionSrcDirs = []
           , optionHiFilesPath = ""
+          , provideInlays = True
+          , inlayLengthCap = Just 32
           }
         Test.myFunRef1TdiAndPosition
         (pure [])

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -54,6 +54,8 @@ defaultTestStaticEnvOptions =
     , optionHieFilesPath = testHieDir
     , optionSrcDirs = testSrcDirs
     , optionHiFilesPath = testHiDir
+    , provideInlays = True
+    , inlayLengthCap = Just 32
     }
 
 initStaticEnvOpts :: StaticEnvOptions -> IO StaticEnv


### PR DESCRIPTION
This fix changes the encoding used in Data.Rope to be UTF-8, which is the encoding that GHC uses. This should fix the obvious issue with inlay hints being misaligned whenever unicode is found in the code (usually in comments), and any other bugs related to misalignment.

Notes:
Implementing this change required upgrading the text-rope version to 0.3 and adding text-rope to the allow-newer field in cabal.project.

Since this was a relatively direct change, there are incomplete pattern matches in cases where a UTF-8 code point could be split in half. However, I don't expect this to happen, provided that we get positions directly from hiedb.