### PR TITLE
introduce a `ghcid` subcommand, use ghcid's `pwd` when pushing diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ errors.txt
 .test_builds/
 result/
 ghc-out.json
+.ghcid_session

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Other potential sources of static information include haddock files as an altern
 to definition.
 Future features using existing static sources include auto import resolution code actions, autocomplete based on hiedb, and call heiarchy
 
+static-ls includes a `ghcid` subcommand which passes the appropriate flags to use ghcid as a source for diagnostics `static-ls ghcid -- -c 'cabal repl foo'`
+
 ## Limitations
 - Must be compiled on the same version of ghc as the project
 - You will need to re-index your hie files once you edit your project

--- a/app/App/Arguments.hs
+++ b/app/App/Arguments.hs
@@ -1,8 +1,8 @@
-module App.Arguments
-  ( execArgParser
-  , handleParseResultWithSuppression
-  , PrgOptions(..)
-  ) where
+module App.Arguments (
+  execArgParser,
+  handleParseResultWithSuppression,
+  PrgOptions (..),
+) where
 
 import Control.Applicative
 import Data.Version (showVersion)
@@ -11,21 +11,21 @@ import Paths_static_ls (version)
 import StaticLS.StaticEnv.Options
 import System.Environment
 import System.Exit
-import Text.Parsec (runParser, sepEndBy, alphaNum, char)
+import Text.Parsec (alphaNum, char, runParser, sepEndBy)
 import Text.Read
 
 currVersion :: String
 currVersion = showVersion version
 
-data PrgOptions =
-  StaticLsOptions
-    { staticEnvOpts :: StaticEnvOptions
-    , showVer :: Bool
-    , showHelp :: Bool
-    }
+data PrgOptions
+  = StaticLsOptions
+      { staticEnvOpts :: StaticEnvOptions
+      , showVer :: Bool
+      , showHelp :: Bool
+      }
   | GHCIDOptions
-    { args :: [String]
-    }
+      { args :: [String]
+      }
 
 -- | Run an argument parser but suppress invalid arguments (simply running the server instead)
 -- Helpful for people on emacs or whose default configurations from HLS pass in
@@ -64,15 +64,16 @@ progParseInfo defaultOpts =
 
 argParser :: StaticEnvOptions -> Parser PrgOptions
 argParser defaultOpts =
-      staticLsParser
-  <|> subparser ghcidParser
-  where
-  ghcidParser =  command "ghcid" $
-    info
-      (GHCIDOptions <$> many (strArgument mempty))
-      (  progDesc "ghcid wrapper that gives static-ls extra information"
-      <> footer "example: static-ls ghcid -- -c 'cabal repl foo'"
-      )
+  staticLsParser
+    <|> subparser ghcidParser
+ where
+  ghcidParser =
+    command "ghcid" $
+      info
+        (GHCIDOptions <$> many (strArgument mempty))
+        ( progDesc "ghcid wrapper that gives static-ls extra information"
+            <> footer "example: static-ls ghcid -- -c 'cabal repl foo'"
+        )
   staticLsParser =
     StaticLsOptions
       <$> staticEnvOptParser defaultOpts

--- a/app/App/Ghcid.hs
+++ b/app/App/Ghcid.hs
@@ -1,0 +1,12 @@
+module App.Ghcid (
+  ghcid,
+) where
+
+import System.Directory (getCurrentDirectory)
+import System.Process.Typed (proc, runProcess_)
+
+ghcid :: [String] -> IO ()
+ghcid args = do
+  ghcidPwd <- getCurrentDirectory
+  let ghcidProcessConfig = proc "ghcid" $ ["-o", "ghcid.txt", "--setup", ":!pwd > " <> ghcidPwd <> "/.ghcid_session"] <> args
+  runProcess_ ghcidProcessConfig

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,11 +6,24 @@ import Control.Error
 import StaticLS.Logger
 import StaticLS.Server qualified as StaticLS
 import StaticLS.StaticEnv.Options (defaultStaticEnvOptions)
+import Options.Applicative
+import System.Directory (getCurrentDirectory)
+import System.Process.Typed (proc, runProcess_)
+import qualified Data.Text as T
+import Control.Monad.Reader (runReaderT)
 
 main :: IO ()
 main = do
   logger <- StaticLS.Logger.setupLogger
   mFileConfig <- getFileConfig logger
-  staticEnvOpts <- App.execArgParser (fromMaybe defaultStaticEnvOptions mFileConfig)
-  _ <- StaticLS.runServer staticEnvOpts logger
-  pure ()
+  App.execArgParser (fromMaybe defaultStaticEnvOptions mFileConfig) >>= \case
+    Success (App.GHCIDOptions{args}) -> do
+      flip runReaderT logger $ logInfo "starting ghcid"
+      flip runReaderT logger $ logInfo (T.pack . show $ args)
+      ghcidPwd <- getCurrentDirectory
+      let ghcidProcessConfig = proc "ghcid" $ ["-o", "ghcid.txt", "--setup", ":!pwd > " <> ghcidPwd <> "/.ghcid_session"] <> args
+      runProcess_ ghcidProcessConfig
+    argsRes -> do
+      staticEnvOpts <- App.handleParseResultWithSuppression defaultStaticEnvOptions argsRes
+      _ <- StaticLS.runServer staticEnvOpts logger
+      pure ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,28 +1,20 @@
 module Main where
 
 import App.Arguments qualified as App
+import App.Ghcid (ghcid)
 import App.Configuration
 import Control.Error
 import StaticLS.Logger
 import StaticLS.Server qualified as StaticLS
 import StaticLS.StaticEnv.Options (defaultStaticEnvOptions)
 import Options.Applicative
-import System.Directory (getCurrentDirectory)
-import System.Process.Typed (proc, runProcess_)
-import qualified Data.Text as T
-import Control.Monad.Reader (runReaderT)
 
 main :: IO ()
 main = do
   logger <- StaticLS.Logger.setupLogger
   mFileConfig <- getFileConfig logger
   App.execArgParser (fromMaybe defaultStaticEnvOptions mFileConfig) >>= \case
-    Success (App.GHCIDOptions{args}) -> do
-      flip runReaderT logger $ logInfo "starting ghcid"
-      flip runReaderT logger $ logInfo (T.pack . show $ args)
-      ghcidPwd <- getCurrentDirectory
-      let ghcidProcessConfig = proc "ghcid" $ ["-o", "ghcid.txt", "--setup", ":!pwd > " <> ghcidPwd <> "/.ghcid_session"] <> args
-      runProcess_ ghcidProcessConfig
+    Success (App.GHCIDOptions{args}) -> ghcid args
     argsRes -> do
       staticEnvOpts <- App.handleParseResultWithSuppression defaultStaticEnvOptions argsRes
       _ <- StaticLS.runServer staticEnvOpts logger

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,20 +1,20 @@
 module Main where
 
 import App.Arguments qualified as App
-import App.Ghcid (ghcid)
 import App.Configuration
+import App.Ghcid (ghcid)
 import Control.Error
+import Options.Applicative
 import StaticLS.Logger
 import StaticLS.Server qualified as StaticLS
 import StaticLS.StaticEnv.Options (defaultStaticEnvOptions)
-import Options.Applicative
 
 main :: IO ()
 main = do
   logger <- StaticLS.Logger.setupLogger
   mFileConfig <- getFileConfig logger
   App.execArgParser (fromMaybe defaultStaticEnvOptions mFileConfig) >>= \case
-    Success (App.GHCIDOptions{args}) -> ghcid args
+    Success (App.GHCIDOptions {args}) -> ghcid args
     argsRes -> do
       staticEnvOpts <- App.handleParseResultWithSuppression defaultStaticEnvOptions argsRes
       _ <- StaticLS.runServer staticEnvOpts logger

--- a/src/StaticLS/GhcidSession.hs
+++ b/src/StaticLS/GhcidSession.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module StaticLS.GhcidSession where
+
+import Data.Path
+import Text.Parsec
+import Text.Parsec.Text (Parser)
+import Control.Exception (displayException)
+
+data GhcidSession = GhcidSession
+  { workingDirectory :: AbsPath
+  }
+
+parseGhcidSession :: Parser GhcidSession
+parseGhcidSession = do
+  workingDirectoryFP <- manyTill anyChar newline
+  workingDirectory <- case filePathToAbsThrow workingDirectoryFP of
+    Left e -> fail $ displayException e
+    Right x -> pure x
+
+  eof *> pure GhcidSession{..}

--- a/src/StaticLS/GhcidSession.hs
+++ b/src/StaticLS/GhcidSession.hs
@@ -2,10 +2,10 @@
 
 module StaticLS.GhcidSession where
 
+import Control.Exception (displayException)
 import Data.Path
 import Text.Parsec
 import Text.Parsec.Text (Parser)
-import Control.Exception (displayException)
 
 data GhcidSession = GhcidSession
   { workingDirectory :: AbsPath
@@ -18,4 +18,4 @@ parseGhcidSession = do
     Left e -> fail $ displayException e
     Right x -> pure x
 
-  eof *> pure GhcidSession{..}
+  eof *> pure GhcidSession {..}

--- a/src/StaticLS/Handlers.hs
+++ b/src/StaticLS/Handlers.hs
@@ -315,7 +315,7 @@ handleGhcidFileChange = do
     staticEnv <- lift StaticEnv.getStaticEnv
     pathPrefix <- case eghcid_session of
       Left e -> do
-        lift $ logInfo $ T.unwords ["could not parse ghcid_session", T.pack . Exception.displayException $ e]
+        lift $ logInfo $ T.unwords ["could not parse ghcid_session", T.pack . show $ e]
         pure (staticEnv.wsRoot Path.</>)
       Right ghcid_session -> pure (ghcid_session.workingDirectory Path.</>)
     let diags = IDE.Diagnostics.ParseGHC.parse pathPrefix contents

--- a/src/StaticLS/Handlers.hs
+++ b/src/StaticLS/Handlers.hs
@@ -23,6 +23,7 @@ import Language.LSP.Server (
  )
 import Language.LSP.Server qualified as LSP
 import Language.LSP.VFS (VirtualFile (..))
+import StaticLS.GhcidSession
 import StaticLS.HIE.File qualified as HIE.File
 import StaticLS.IDE.CodeActions (getCodeActions)
 import StaticLS.IDE.CodeActions qualified as IDE.CodeActions
@@ -49,9 +50,8 @@ import StaticLS.StaticEnv.Options (StaticEnvOptions (..))
 import StaticLS.Utils
 import System.Directory (doesFileExist)
 import System.FSNotify qualified as FSNotify
+import Text.Parsec.Text qualified as Parsec
 import UnliftIO.Exception qualified as Exception
-import StaticLS.GhcidSession
-import qualified Text.Parsec.Text as Parsec
 
 -----------------------------------------------------------------
 --------------------- LSP event handlers ------------------------
@@ -314,10 +314,10 @@ handleGhcidFileChange = do
     eghcid_session <- liftIO $ Parsec.parseFromFile parseGhcidSession ".ghcid_session"
     staticEnv <- lift StaticEnv.getStaticEnv
     pathPrefix <- case eghcid_session of
-          Left e -> do
-            lift $ logInfo $ T.unwords ["could not parse ghcid_session", T.pack . Exception.displayException $ e]
-            pure (staticEnv.wsRoot Path.</>)
-          Right ghcid_session -> pure (ghcid_session.workingDirectory Path.</>)
+      Left e -> do
+        lift $ logInfo $ T.unwords ["could not parse ghcid_session", T.pack . Exception.displayException $ e]
+        pure (staticEnv.wsRoot Path.</>)
+      Right ghcid_session -> pure (ghcid_session.workingDirectory Path.</>)
     let diags = IDE.Diagnostics.ParseGHC.parse pathPrefix contents
     lift $ logInfo $ "diags: " <> T.pack (show diags)
     clearDiagnostics

--- a/src/StaticLS/HieView/View.hs
+++ b/src/StaticLS/HieView/View.hs
@@ -157,9 +157,9 @@ data NodeOrigin
 type SourcedNodeInfo a = Map NodeOrigin (NodeInfo a)
 
 $( fold
-     [ makePrisms ''ContextInfo
-     , makePrisms ''Identifier
-     ]
+    [ makePrisms ''ContextInfo
+    , makePrisms ''Identifier
+    ]
  )
 
 readFile :: (MonadIO m) => FilePath -> MaybeT m File

--- a/src/StaticLS/HieView/View.hs
+++ b/src/StaticLS/HieView/View.hs
@@ -157,9 +157,9 @@ data NodeOrigin
 type SourcedNodeInfo a = Map NodeOrigin (NodeInfo a)
 
 $( fold
-    [ makePrisms ''ContextInfo
-    , makePrisms ''Identifier
-    ]
+     [ makePrisms ''ContextInfo
+     , makePrisms ''Identifier
+     ]
  )
 
 readFile :: (MonadIO m) => FilePath -> MaybeT m File

--- a/static-ls.cabal
+++ b/static-ls.cabal
@@ -174,6 +174,7 @@ library
       StaticLS.StaticEnv.Options
       StaticLS.Tree
       StaticLS.Utils
+      StaticLS.GhcidSession
   other-modules:
       Paths_static_ls
   autogen-modules:

--- a/static-ls.cabal
+++ b/static-ls.cabal
@@ -326,6 +326,7 @@ executable static-ls
   other-modules:
       App.Arguments
       App.Configuration
+      App.Ghcid
       Paths_static_ls
   autogen-modules:
       Paths_static_ls


### PR DESCRIPTION
I use static-ls in a cabal project with many packages, and diagnostics point to the wrong directory since static-ls's pwd is different from ghcid's. 

it seems convenient for the user, and for the maintainers, to introduce a subcommand that allows `static-ls` itself to provide ghcid with the appropriate flags to read the diagnostics and pwd from ghcid