### PR TITLE
Adding jump to definition for yesod routes

### DIFF
--- a/src/StaticLS/HIE/File.hs
+++ b/src/StaticLS/HIE/File.hs
@@ -5,6 +5,7 @@ module StaticLS.HIE.File (
   modToSrcFile,
   srcFilePathToHieFilePath,
   hieFilePathToSrcFilePath,
+  hieFilePathToSrcFilePathFromFile,
   -- | An alternate way of getting file information by pre-indexing hie files -
   -- far slower on startup and currently unused
   getHieFileMap,

--- a/src/StaticLS/HIE/Position.hs
+++ b/src/StaticLS/HIE/Position.hs
@@ -6,6 +6,7 @@ import Data.Pos (Pos (..))
 
 -- | LSP Position is 0 indexed
 -- Note HieDbCoords are 1 indexed
+-- (Line, Column)
 type HieDbCoords = (Int, Int)
 
 data UIntConversionException = UIntConversionException


### PR DESCRIPTION
Adds a jump-to-definition feature for `.yesodroutes` file. Routes are written in the format HandlerNameR Method, e.g. `SignUpR POST`. We generate the corresponding function name, e.g. `postSignUpR`, and search for/return its location using hiedb.