### PR TITLE
Draft: Go to definition for Template Haskell (AmeriHac)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,14 @@ See [Advanced setup](docs/advanced-setup.md) for additional options
      - -Werror=deferred-type-errors
      - -Werror=deferred-out-of-scope-variables
      - -fno-defer-typed-holes
+     - -ddump-splices
+     - -ddump-to-file
      ```
   
-    These flags will allow hie files to be refreshed even if compilation fails to
+    The first four flags will allow hie files to be refreshed even if compilation fails to
     type check and will ensure that type check failures are still thrown as
     errors.
+    The last two supports go to definition for template haskell.
 
     - If you're using hpack you can add:
       ```
@@ -74,6 +77,8 @@ See [Advanced setup](docs/advanced-setup.md) for additional options
           - -Werror=deferred-type-errors
           - -Werror=deferred-out-of-scope-variables
           - -fno-defer-typed-holes
+          - -ddump-splices
+          - -ddump-to-file
       ```
       to  your `package.yaml`. See this project's `package.yaml` or `static-ls.cabal` for examples
     - You may instead add the following to your `cabal.project.local` file:
@@ -87,6 +92,8 @@ See [Advanced setup](docs/advanced-setup.md) for additional options
           -Werror=deferred-type-errors
           -Werror=deferred-out-of-scope-variables
           -fno-defer-typed-holes
+          -ddump-splices
+          -ddump-to-file
       ```
     
 2. You can index your project in hiedb running:

--- a/src/StaticLS/StaticEnv.hs
+++ b/src/StaticLS/StaticEnv.hs
@@ -13,6 +13,7 @@ module StaticLS.StaticEnv (
   HasStaticEnv,
   HasCallStack,
   runStaticEnv,
+  loadTHSpliceLocs,
 )
 where
 
@@ -26,6 +27,26 @@ import Database.SQLite.Simple (SQLError)
 import HieDb qualified
 import StaticLS.Logger
 import StaticLS.StaticEnv.Options (StaticEnvOptions (..))
+import Data.LineColRange (LineColRange (..))
+import Data.Map (Map)
+import Data.Text (Text)
+import System.Directory (getDirectoryContents)
+import qualified System.Directory as Directory
+import Data.Foldable (for_)
+import System.FilePath ((</>))
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
+import Data.Traversable (for)
+import qualified Data.Map as Map
+import Text.Parsec.Text (Parser)
+import qualified Text.Parsec as Parsec
+import Text.Parsec (ParseError)
+import Data.LineCol (LineCol(..))
+import Control.Monad (void)
+import qualified Data.Either as Either
+import Text.Read (readMaybe)
+import Data.Pos (Pos(..))
+import GHC (load)
 
 type HieDbPath = FilePath
 
@@ -41,6 +62,117 @@ data HieDbException
   deriving (Show)
 
 instance Exception HieDbException
+
+type ThPath = FilePath
+
+-- Helps maps from the source containing template haskell to the dump
+-- TODO temporary data structure
+type THSpliceLoc = Map (AbsPath, LineColRange) THInfo
+
+data THInfo = THInfo
+  { -- | The original template haskell source code
+    --  e.g. deriveJSON defaultOptions ''D
+    declaration :: Text
+    -- | Path to the original template haskell source
+  , origPath :: FilePath
+    -- | Location of the dump
+  , spliceDumpPath :: ThPath
+    -- | Range of original template haskell source
+  , lineColRange :: LineColRange
+  -- , generatedCode :: Text -- TODO I don't think we actually need this information
+  } deriving (Show, Eq)
+
+parseTHInfos :: FilePath -> Text -> Either ParseError [THInfo]
+parseTHInfos spliceDumpPath content = Parsec.parse (do
+  -- break if there's a path in the first column followed by :
+  parseTHInfo spliceDumpPath `Parsec.sepBy` (Parsec.try $ do
+    _ <- Parsec.many (Parsec.noneOf "\n")
+    _ <- Parsec.char ':'
+    _ <- Parsec.many (Parsec.noneOf "\n")
+    _ <- Parsec.newline
+    pure ())) spliceDumpPath content
+
+
+parseTHInfo :: FilePath -> Parser THInfo
+parseTHInfo spliceDumpPath = do
+  -- parse until :
+  Parsec.skipMany (Parsec.noneOf ":")
+  origPath <- Parsec.many (Parsec.noneOf ":")
+  _ <- Parsec.char ':'
+  lineColRange <- parseLineColRange
+  _ <- Parsec.string ": Splicing declarations\n"
+  declaration <- parseDeclaration
+  -- now just ignore all text until next path
+  pure $ THInfo {
+    declaration = declaration
+  , origPath = origPath
+  , lineColRange = lineColRange
+  , spliceDumpPath = spliceDumpPath
+  }
+
+
+parseDeclaration :: Parser Text
+parseDeclaration = Text.pack <$> Parsec.manyTill Parsec.anyChar (Parsec.try $ do
+    _ <- Parsec.newline
+    _ <- Parsec.string "=======>"
+    _ <- Parsec.newline
+    pure ())
+
+-- Possible formats
+-- 27:2-32
+-- (27,2)-(30,12)
+-- etc?
+parseLineColRange :: Parser LineColRange
+parseLineColRange = parseSingleRow -- TODO <|> parseMultiRow
+  where
+    parseSingleRow = do
+      row <- parseDigit
+      void $ Parsec.char ':'
+      columnStart <- parseDigit
+      void $ Parsec.char '-'
+      columnEnd <- parseDigit
+      let lineColStart = LineCol (Pos  row) (Pos columnStart)
+          lineColEnd = LineCol (Pos  row) (Pos columnEnd)
+      pure $ LineColRange lineColStart lineColEnd
+
+parseDigit :: Parser Int
+parseDigit = do
+  raw <- Parsec.many Parsec.digit
+  case readMaybe @Int raw of
+    Nothing -> fail $ "Expected a digit but got: " <> raw
+    Just n -> pure n
+
+-- TODO
+mkThSpliceLoc :: [THInfo] -> THSpliceLoc
+mkThSpliceLoc = undefined
+
+data BuildSystem = Cabal | Stack | Buck2 deriving (Show, Eq)
+
+loadTHSpliceLocs :: IO THSpliceLoc
+loadTHSpliceLocs = do
+    -- Examples 
+    -- /Users/mac/dev/haskell-playground/dist-newstyle/build/aarch64-osx/ghc-9.8.4/haskell-playground-0.1.0.0/build/src/StaticLs.dump-splices
+    buildSystem <- getBuildSystem
+    project <- getProjectName
+    -- let baseDir = case buildSystem of
+    --       Cabal -> "dist-newstyle/build/aarch64-osx/ghc-*/" <> project <> "-*/build/src/"
+    --       Stack -> undefined --TODO
+    --       Buck2 -> undefined --TODO
+    let baseDir = "/Users/mac/dev/haskell-playground/dist-newstyle/build/aarch64-osx/ghc-9.8.4/haskell-playground-0.1.0.0/build/src/StaticLs.dump-splices"
+    spliceDumpFiles <- Directory.getDirectoryContents $ Text.unpack baseDir
+    thInfoEithers <- for spliceDumpFiles $ \file -> do
+      text <- TextIO.readFile file
+      pure $ parseTHInfos file text
+    let thInfos = (Either.fromRight []) =<< thInfoEithers
+    pure $ mkThSpliceLoc thInfos
+  where
+    -- TODO just hard coding these for stubs
+    getBuildSystem :: IO BuildSystem
+    getBuildSystem = pure Cabal
+    -- TODO
+    getProjectName :: IO Text
+    getProjectName = pure "haskell-playground"
+
 
 -- | Imuttable references to "static sources" of language information. Should
 --     be low overhead and should be sources for language information only.
@@ -62,6 +194,9 @@ data StaticEnv = StaticEnv
   -- ^ directories to search for source code in order of priority (immutable directories)
   , allSrcDirs :: [AbsPath]
   -- ^ directories to search for source code in order of priority (muttable and imuttable directories)
+  , thSpliceLoc :: THSpliceLoc
+  -- ^ Map from template haskell source to generated code dump
+  -- TODO eventually we might want to load this on demand or something but this might be sufficent for a POC
   , fourmoluCommand :: Maybe FilePath
   -- ^ path to fourmolu binary
   }
@@ -89,6 +224,7 @@ initStaticEnv wsRoot staticEnvOptions = do
       immutableSrcDirs = fmap ((wsRoot Path.</>) . Path.filePathToRel) (staticEnvOptions.optionImmutableSrcDirs)
       allSrcDirs = mutableSrcDirs <> immutableSrcDirs
       hiFilesPath = wsRoot Path.</> (Path.filePathToRel staticEnvOptions.optionHiFilesPath)
+  thSpliceLoc <- loadTHSpliceLocs `catch` (\(e :: SomeException) -> pure Map.empty) -- TODO log the exception
   let serverStaticEnv =
         StaticEnv
           { hieDbPath = databasePath
@@ -99,6 +235,7 @@ initStaticEnv wsRoot staticEnvOptions = do
           , mutableSrcDirs = mutableSrcDirs
           , immutableSrcDirs = immutableSrcDirs
           , allSrcDirs = allSrcDirs
+          , thSpliceLoc = thSpliceLoc
           , fourmoluCommand = staticEnvOptions.fourmoluCommand
           }
   pure serverStaticEnv


### PR DESCRIPTION
## Go to Definition for Template Haskell

This is a draft PR to support go to definition for Template Haskell. @Disco-Dave and I worked on this at AmeriHac with @josephsumabat.
in case I never come around to finishing it here's a draft PR that details my work so someone else may complete it.

As a POC I was planning on:
1. On boot (or when there's a rebuild) scan for all template haskell dump files
1. Parse the dump files extracting info detailed in the next section
1. Initialize or update a Map where the index is the original source and ranges
1. When a user sends a request to goto in template haskell do a lookup
1. Find the generated code location to jump to the dump file

Talking to @josephsumabat we might not want this exactly but we can change it later on.

## Parsing

We should be able to extract a list of the following from each template haskell dump file (e.g. `[ThInfo]):
* Original Template Haskell File Path and Range
* The original declaration
* Generated code

For example a TH dump is in this format:

Example of splice file path: 
```
src/StaticLs.hs:16:2-32: Splicing declarations
    deriveJSON defaultOptions ''D
  ======>
    instance sn-2.2.3.0-434dc366:Data.Aeson.Types.ToJSON.ToJSON D where
... Generated code
    instance sn-2.2.3.0-434dc366:Data.Aeson.Types.FromJSON.FromJSON D where
... Generated code
src/StaticLs.hs:27:2-32: Splicing declarations
    deriveJSON defaultOptions ''E
  ======>
    instance sn-2.2.3.0-434dc366:Data.Aeson.Types.ToJSON.ToJSON E where
...
```

I used parsec since it's already a dependency to load it into the following data type:
```haskell
data THInfo = THInfo
  { -- | The original template haskell source code
    --  e.g. deriveJSON defaultOptions ''D
    declaration :: Text
    -- | Path to the original template haskell source
  , origPath :: FilePath
    -- | Location of the dump
  , spliceDumpPath :: ThPath
    -- | Range of original template haskell source
  , lineColRange :: LineColRange
  -- , generatedCode :: Text -- TODO I don't think we actually need this
  } deriving (Show, Eq)
```

AI Disclaimer: I am not that good at parser combinator libraries so I did use an LLM. I didn't get around to testing it yet.

## TODOs

- [ ] There's a few TODOs in the source code resolve those
- [ ] Reorganize modules probably move dump file parser to it's own module

### Finding dump files

I didn't see a good way to set a location for dump files to be put into so my current implementation depends on what build system you use.
Cabal has a particular place it dumps to.

I had trouble finding where Stack dumps to and there's some posts where people mention it should be in
a certain location and I wouldn't see it there, so I switched to Cabal just to get something working.


There's also a stub for Buck2