### PR TITLE
Support ghc 9.12+

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704317660,
-        "narHash": "sha256-RQc7gxeNZQ1nJRcU82EAH1L0BU7DP2ClqZhOkd9/oos=",
+        "lastModified": 1778110645,
+        "narHash": "sha256-O/w4nhRFjTxYRGYuIuY616HIXVFvVwzqeLjCR21fMt8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "020146194a59f1ec31eece8f7c0ff3643a4af80c",
+        "rev": "46dfb6c2c2387cf1da1b89ef378fecc2cb9c46ac",
         "type": "github"
       },
       "original": {

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -7,6 +7,14 @@ let
     fetchSubmodules = true;
   };
 
+  # GHC 9.12 test fixes merged upstream (well-typed/optics#512) but no
+  # Hackage release yet; tracked in GHC #25631 and GHC #25883
+  optics-repo = {
+    url = "https://github.com/well-typed/optics";
+    sha256 = "sha256-1Eoyaf0KUEtNL48Lb78NTSpx5LJaDDInguea306neXI=";
+    rev = "d3f507217bb828ec97d3ead69b0b4319941c0ec5";
+  };
+
 in
   ghcVersion:
   self: super: {
@@ -15,8 +23,8 @@ in
     all-cabal-hashes =
         # Update revision to match required hackage
         super.fetchurl {
-          url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/59b02844f778d7cc71d2a62ee05c37e17b396051.tar.gz";
-          sha256 = "sha256-NUuQW59vzpXufNpAq4qwx5R0/2TwgDgtapjDSdIybhQ=";
+          url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/e82a78bdc7a453ec96d5d8879bb9862b63a6f1b5.tar.gz";
+          sha256 = "sha256-gV4iJvIfwSSrdYJeHQ6d8qchRP9hRGP2pj8xMkcJoCQ=";
     };
 
     haskellPackages = super.haskell.packages.${self.ghcVersion}.override {
@@ -47,11 +55,17 @@ in
           rev = "ec14d702660c79a907e9c45812958cd0df0f036f";
         }) {};
 
-        hiedb = self.haskell.lib.dontCheck (haskellSuper.callHackage "hiedb" "0.6.0.1" {});
+        hiedb = self.haskell.lib.dontCheck (haskellSuper.callHackage "hiedb" "0.6.0.2" {});
+
         text-rope = haskellSuper.callHackage "text-rope" "0.3" {};
 
-        lsp-types = haskellSuper.callHackage "lsp-types" "2.3.0.0" {};
-        lsp = haskellSuper.callHackage "lsp" "2.7.0.0" {};
+        lsp-types = haskellSuper.callHackage "lsp-types" "2.3.0.1" {};
+
+        lsp = haskellSuper.callHackage "lsp" "2.7.0.1" {};
+
+        optics = self.haskell.lib.dontCheck (
+          haskellSuper.callCabal2nix
+          "optics" "${(super.fetchgit optics-repo)}/optics" {});
       };
     };
   }

--- a/package.yaml
+++ b/package.yaml
@@ -18,17 +18,18 @@ extra-doc-files:
 tested-with:
   - GHC == 9.4.4
   - GHC == 9.6.3
+  - GHC == 9.12.2
 
 dependencies:
   - array >= 0.5.4 && < 0.6
-  - base >= 4.17.0 && < 4.21
+  - base >= 4.17.0 && < 4.22
   - containers >= 0.6.0 && < 0.8
   - unordered-containers >= 0.2 && < 0.3
   - errors >= 2.3.0 && < 2.4
-  - extra >= 1.7.12 && < 1.8
+  - extra >= 1.7.12 && < 1.9
   - directory >= 1.3.7 && < 1.4
   - filepath
-  - ghc >= 9.4.3 && < 9.11
+  - ghc >= 9.4.3 && < 9.13
   - ghc-paths >= 0.1.0 && < 0.2
   - haskell-lexer >=1.1.1 && <1.2.0
   - hiedb >= 0.6 && < 0.7
@@ -37,7 +38,7 @@ dependencies:
   - mtl >= 2.2.2 && < 2.4
   - parsec >= 3.1.0 && < 3.2
   - sqlite-simple >= 0.4.18 && < 0.5
-  - template-haskell >= 2.19.0 && < 2.23
+  - template-haskell >= 2.19.0 && < 2.24
   - text >= 2.0.1 && < 2.2
   - time >= 1.0 && < 2.0
   - bytestring >=0.10 && <0.13

--- a/static-ls.cabal
+++ b/static-ls.cabal
@@ -19,6 +19,7 @@ build-type:     Simple
 tested-with:
     GHC == 9.4.4
   , GHC == 9.6.3
+  , GHC == 9.12.2
 extra-doc-files:
     README.md
     CHANGELOG.md
@@ -52,7 +53,7 @@ library
     , aeson >=2 && <2.3
     , array >=0.5.4 && <0.6
     , async
-    , base >=4.17.0 && <4.21
+    , base >=4.17.0 && <4.22
     , bytestring >=0.10 && <0.13
     , co-log-core ==0.3.*
     , containers >=0.6.0 && <0.8
@@ -60,10 +61,10 @@ library
     , directory >=1.3.7 && <1.4
     , errors >=2.3.0 && <2.4
     , exceptions
-    , extra >=1.7.12 && <1.8
+    , extra >=1.7.12 && <1.9
     , filepath
     , fsnotify
-    , ghc >=9.4.3 && <9.11
+    , ghc >=9.4.3 && <9.13
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
@@ -82,7 +83,7 @@ library
     , row-types
     , sqlite-simple >=0.4.18 && <0.5
     , stm
-    , template-haskell >=2.19.0 && <2.23
+    , template-haskell >=2.19.0 && <2.24
     , text >=2.0.1 && <2.2
     , text-range
     , text-rope ==0.3
@@ -206,7 +207,7 @@ executable print-hie
     , aeson >=2 && <2.3
     , array >=0.5.4 && <0.6
     , async
-    , base >=4.17.0 && <4.21
+    , base >=4.17.0 && <4.22
     , bytestring >=0.10 && <0.13
     , co-log-core ==0.3.*
     , containers >=0.6.0 && <0.8
@@ -214,10 +215,10 @@ executable print-hie
     , directory >=1.3.7 && <1.4
     , errors >=2.3.0 && <2.4
     , exceptions
-    , extra >=1.7.12 && <1.8
+    , extra >=1.7.12 && <1.9
     , filepath
     , fsnotify
-    , ghc >=9.4.3 && <9.11
+    , ghc >=9.4.3 && <9.13
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
@@ -238,7 +239,7 @@ executable print-hie
     , sqlite-simple >=0.4.18 && <0.5
     , static-ls
     , stm
-    , template-haskell >=2.19.0 && <2.23
+    , template-haskell >=2.19.0 && <2.24
     , text >=2.0.1 && <2.2
     , text-range
     , text-rope ==0.3
@@ -275,7 +276,7 @@ executable static-ls
     , aeson >=2 && <2.3
     , array >=0.5.4 && <0.6
     , async
-    , base >=4.17.0 && <4.21
+    , base >=4.17.0 && <4.22
     , bytestring >=0.10 && <0.13
     , co-log-core ==0.3.*
     , containers >=0.6.0 && <0.8
@@ -283,10 +284,10 @@ executable static-ls
     , directory >=1.3.7 && <1.4
     , errors >=2.3.0 && <2.4
     , exceptions
-    , extra >=1.7.12 && <1.8
+    , extra >=1.7.12 && <1.9
     , filepath
     , fsnotify
-    , ghc >=9.4.3 && <9.11
+    , ghc >=9.4.3 && <9.13
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
@@ -307,7 +308,7 @@ executable static-ls
     , sqlite-simple >=0.4.18 && <0.5
     , static-ls
     , stm
-    , template-haskell >=2.19.0 && <2.23
+    , template-haskell >=2.19.0 && <2.24
     , text >=2.0.1 && <2.2
     , text-range
     , text-rope ==0.3
@@ -360,7 +361,7 @@ test-suite expect_tests
     , aeson >=2 && <2.3
     , array >=0.5.4 && <0.6
     , async
-    , base >=4.17.0 && <4.21
+    , base >=4.17.0 && <4.22
     , bytestring >=0.10 && <0.13
     , co-log-core ==0.3.*
     , containers >=0.6.0 && <0.8
@@ -368,10 +369,10 @@ test-suite expect_tests
     , directory >=1.3.7 && <1.4
     , errors >=2.3.0 && <2.4
     , exceptions
-    , extra >=1.7.12 && <1.8
+    , extra >=1.7.12 && <1.9
     , filepath
     , fsnotify
-    , ghc >=9.4.3 && <9.11
+    , ghc >=9.4.3 && <9.13
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
@@ -395,7 +396,7 @@ test-suite expect_tests
     , stm
     , tasty
     , tasty-expect
-    , template-haskell >=2.19.0 && <2.23
+    , template-haskell >=2.19.0 && <2.24
     , text >=2.0.1 && <2.2
     , text-range
     , text-rope ==0.3
@@ -434,7 +435,7 @@ test-suite static-ls-test
     , aeson >=2 && <2.3
     , array >=0.5.4 && <0.6
     , async
-    , base >=4.17.0 && <4.21
+    , base >=4.17.0 && <4.22
     , bytestring >=0.10 && <0.13
     , co-log-core ==0.3.*
     , containers >=0.6.0 && <0.8
@@ -442,10 +443,10 @@ test-suite static-ls-test
     , directory >=1.3.7 && <1.4
     , errors >=2.3.0 && <2.4
     , exceptions
-    , extra >=1.7.12 && <1.8
+    , extra >=1.7.12 && <1.9
     , filepath
     , fsnotify
-    , ghc >=9.4.3 && <9.11
+    , ghc >=9.4.3 && <9.13
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
@@ -467,7 +468,7 @@ test-suite static-ls-test
     , sqlite-simple >=0.4.18 && <0.5
     , static-ls
     , stm
-    , template-haskell >=2.19.0 && <2.23
+    , template-haskell >=2.19.0 && <2.24
     , text >=2.0.1 && <2.2
     , text-range
     , text-rope ==0.3

--- a/static-ls.cabal
+++ b/static-ls.cabal
@@ -68,7 +68,7 @@ library
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
-    , haskell-lexer >=1.1.1 && <1.2.0
+    , haskell-lexer >=1.1.1 && <1.3
     , hiedb ==0.6.*
     , lens
     , lsp >=2.4.0.0 && <2.8.0.0
@@ -222,7 +222,7 @@ executable print-hie
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
-    , haskell-lexer >=1.1.1 && <1.2.0
+    , haskell-lexer >=1.1.1 && <1.3
     , hiedb ==0.6.*
     , lens
     , lsp >=2.4.0.0 && <2.8.0.0
@@ -291,7 +291,7 @@ executable static-ls
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
-    , haskell-lexer >=1.1.1 && <1.2.0
+    , haskell-lexer >=1.1.1 && <1.3
     , hiedb ==0.6.*
     , lens
     , lsp >=2.4.0.0 && <2.8.0.0
@@ -376,7 +376,7 @@ test-suite expect_tests
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
-    , haskell-lexer >=1.1.1 && <1.2.0
+    , haskell-lexer >=1.1.1 && <1.3
     , hiedb ==0.6.*
     , hspec ==2.*
     , lens
@@ -450,7 +450,7 @@ test-suite static-ls-test
     , ghc-paths >=0.1.0 && <0.2
     , hashable
     , haskell-ast
-    , haskell-lexer >=1.1.1 && <1.2.0
+    , haskell-lexer >=1.1.1 && <1.3
     , hiedb ==0.6.*
     , hspec ==2.*
     , lens


### PR DESCRIPTION
Tested on GHC 9.12.2, all tests passing locally for me. 

At Arista Networks we're on a higher GHC version that static-ls supports. I'd like to try to get it building with alloglot if possible. 